### PR TITLE
Send error message passed by collector instead of generic failure error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- `client.UploadMetrics` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` now returns error shared by collector instead of generic retry-able failure error for retry-able applicable code. (#5536) 
+- `client.UploadMetrics` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` now returns error shared by collector instead of generic retry-able failure error for retry-able applicable code. (#5537) 
 - `Tracer.Start` in `go.opentelemetry.io/otel/trace/noop` no longer allocates a span for empty span context. (#5457)
 - Upgrade `go.opentelemetry.io/otel/semconv/v1.25.0` to `go.opentelemetry.io/otel/semconv/v1.26.0` in `go.opentelemetry.io/otel/example/otel-collector`. (#5490)
 - Upgrade `go.opentelemetry.io/otel/semconv/v1.25.0` to `go.opentelemetry.io/otel/semconv/v1.26.0` in `go.opentelemetry.io/otel/example/zipkin`. (#5490)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- `client.UploadMetrics` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` now returns error shared by collector instead of generic retry-able failure error for retry-able applicable code. (#5536) 
 - `Tracer.Start` in `go.opentelemetry.io/otel/trace/noop` no longer allocates a span for empty span context. (#5457)
 - Upgrade `go.opentelemetry.io/otel/semconv/v1.25.0` to `go.opentelemetry.io/otel/semconv/v1.26.0` in `go.opentelemetry.io/otel/example/otel-collector`. (#5490)
 - Upgrade `go.opentelemetry.io/otel/semconv/v1.25.0` to `go.opentelemetry.io/otel/semconv/v1.26.0` in `go.opentelemetry.io/otel/example/zipkin`. (#5490)

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/collector.go
@@ -177,7 +177,7 @@ type HTTPResponseError struct {
 }
 
 func (e *HTTPResponseError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Status, e.Err)
+	return e.Err.Error()
 }
 
 func (e *HTTPResponseError) Unwrap() error { return e.Err }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest"
 )
 
 type clientShim struct {
@@ -189,6 +190,33 @@ func TestConfig(t *testing.T) {
 		t.Cleanup(func() { close(rCh) })
 		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
 		assert.NoError(t, exp.Export(ctx, &metricdata.ResourceMetrics{}), "failed retry")
+		assert.Len(t, rCh, 0, "failed HTTP responses did not occur")
+	})
+
+	t.Run("WithRetryAndExporterErr", func(t *testing.T) {
+		exporterErr := errors.New("rpc error: code = Unavailable desc = service.name not found in resource attributes")
+		rCh := make(chan otest.ExportResult, 1)
+		header := http.Header{http.CanonicalHeaderKey("Retry-After"): {"10"}}
+		rCh <- otest.ExportResult{Err: &otest.HTTPResponseError{
+			Status: http.StatusServiceUnavailable,
+			Err:    exporterErr,
+			Header: header,
+		}}
+
+		exp, coll := factoryFunc("", rCh, WithRetry(RetryConfig{
+			Enabled:         true,
+			InitialInterval: time.Nanosecond,
+			MaxInterval:     time.Millisecond,
+			MaxElapsedTime:  time.Minute,
+		}))
+		ctx := context.Background()
+		t.Cleanup(func() { require.NoError(t, coll.Shutdown(ctx)) })
+		// Push this after Shutdown so the HTTP server doesn't hang.
+		t.Cleanup(func() { close(rCh) })
+		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+		target := exp.Export(ctx, &metricdata.ResourceMetrics{})
+		assert.ErrorAs(t, fmt.Errorf("failed to upload metrics: %s", exporterErr.Error()), &target)
 		assert.Len(t, rCh, 0, "failed HTTP responses did not occur")
 	})
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/collector.go
@@ -177,7 +177,7 @@ type HTTPResponseError struct {
 }
 
 func (e *HTTPResponseError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Status, e.Err)
+	return e.Err.Error()
 }
 
 func (e *HTTPResponseError) Unwrap() error { return e.Err }

--- a/internal/shared/otlp/otlpmetric/otest/collector.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/otest/collector.go.tmpl
@@ -177,7 +177,7 @@ type HTTPResponseError struct {
 }
 
 func (e *HTTPResponseError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Status, e.Err)
+	return e.Err.Error()
 }
 
 func (e *HTTPResponseError) Unwrap() error { return e.Err }


### PR DESCRIPTION
### Problem Statement

If user forget to add attribute service.name while creating resource object using `resource.New` and `otlpmetrichttp` with a collector setup of **loadbalancing** exporter (which uses service for routing purpose), error msg that user receives in scenario doesn't say anything about the actual problem, this is the actual error msg that user gets

```
failed to upload metrics: context deadline exceeded: retry-able request failure
```


this doesn't happen with `otlpmetricgrpc` exporter, it sends the actual error message that comes from collector, this is the error msg.

```
failed to upload metrics: context deadline exceeded: rpc error: code = Unavailable desc = unable to get service name
```

Issue: it is difficult to figure out the actual reason behind the problem and it is happening because underlying collector sends the actual reason in response body, which otlpmetrichttp discards in case of `retryable code` and actual issue behind the failure gets missed.

Part1:   otlpmetrichttp -----------api call------------> otel-collector (loadbalancer exporter)

Part2:  otel-collector --- sends error ---> otlpmetric UploadMetrics func

Part3:  otlpmetric UploadMetrics func --- discards body ---> sends error `retry-able request failure` instead of actual error

**Setup Details**

<img width="806" alt="Screenshot 2024-06-24 at 6 30 17 PM" src="https://github.com/pree-dew/opentelemetry-go/assets/132843509/8c29d673-49cc-4fa4-ac62-1e0307d11cf1">


### Proposed Solution

Solution is to parse the response body in case of `retryable code` scenarios also instead of discarding the body and overwrite the error if the response body is not empty, so that the actual message passed by collector via api will be used to give full context to user about the scenario.

Solution will send messages as it is received from collector.
```
failed to upload metrics:unable to get service name
```
